### PR TITLE
Update insights to 3.2 Release

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -40,7 +40,35 @@ if [ ! -d "/usr/local/bin/" ]; then
 fi
 
 # Installing Red Hat Openshift 4.8 CLI
-qs_retry_command 10 wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.8/openshift-client-linux.tar.gz
+# qs_retry_command 10 wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.8/openshift-client-linux.tar.gz
+# rc=$?
+# if [ "$rc" != "0" ]; then
+#   failure_msg="[ERROR] Couldn't download Red Hat OpenShift CLI file."
+#   cfn_init_status
+# fi
+# tar -xvf openshift-client-linux.tar.gz
+# chmod -R 755 oc
+# chmod -R 755 kubectl
+# mv oc /usr/local/bin/oc
+# mv kubectl /usr/local/bin/kubectl
+# rm -f openshift-client-linux.tar.gz
+
+# Installing Red Hat Openshift 4.8 installer
+# wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.8/openshift-install-linux.tar.gz
+# rc=$?
+# if [ "$rc" != "0" ]; then
+#   failure_msg="[ERROR] Couldn't download Red Hat OpenShift installer file."
+#   cfn_init_status
+# fi
+# tar -xvf openshift-install-linux.tar.gz
+# chmod 755 openshift-install
+# mv openshift-install /ibm
+# rm -f openshift-install-linux.tar.gz
+
+# cd ..
+
+# Installing Red Hat Openshift 4.10 CLI
+qs_retry_command 10 wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.10/openshift-client-linux.tar.gz
 rc=$?
 if [ "$rc" != "0" ]; then
   failure_msg="[ERROR] Couldn't download Red Hat OpenShift CLI file."
@@ -53,8 +81,8 @@ mv oc /usr/local/bin/oc
 mv kubectl /usr/local/bin/kubectl
 rm -f openshift-client-linux.tar.gz
 
-# Installing Red Hat Openshift 4.8 installer
-wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.8/openshift-install-linux.tar.gz
+# Installing Red Hat Openshift 4.10 installer
+wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.10/openshift-install-linux.tar.gz
 rc=$?
 if [ "$rc" != "0" ]; then
   failure_msg="[ERROR] Couldn't download Red Hat OpenShift installer file."

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -113,29 +113,6 @@ echo -e "export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64" >> /etc/profile
 source /etc/profile.d/openssl.sh
 openssl version
 
-# Installing python3
-yum install gcc openssl-devel bzip2-devel libffi-devel -y
-curl -O https://www.python.org/ftp/python/3.10.8/Python-3.10.8.tgz
-if [ "$rc" != "0" ]; then
-  failure_msg="[ERROR] Couldn't download python3."
-  cfn_init_status
-fi
-tar -xzf Python-3.10.8.tgz
-rm -rf Python-3.10.8.tgz
-cd Python-3.10.8/
-./configure --prefix=/opt/python3 --enable-optimizations
-make
-make altinstall
-ln -s /opt/python3/bin/python3 /usr/bin/python3
-python3 --version
-# yum install -y python3
-
-# Install pyyaml
-pip3 install pyyaml
-
-# Install Argparse
-pip3 install argparse
-
 # Installing jq
 yum install wget
 wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq
@@ -229,4 +206,16 @@ echo $HOME
 export KUBECONFIG=/root/.kube/config
 echo $KUBECONFIG
 echo $PATH
-python /ibm/gi_install.py --region "${AWS_REGION}" --stack-id "${AWS_STACKID}" --stack-name ${AWS_STACKNAME} --logfile $LOGFILE --loglevel "*=all"
+
+# Switching to python3
+update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+sleep 15
+python --version &> /var/log/userdata.python3_install.log
+
+# Install pyyaml
+pip3 install pyyaml
+
+# Install Argparse
+pip3 install argparse
+
+python2 /ibm/gi_install.py --region "${AWS_REGION}" --stack-id "${AWS_STACKID}" --stack-name ${AWS_STACKNAME} --logfile $LOGFILE --loglevel "*=all"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -114,19 +114,21 @@ source /etc/profile.d/openssl.sh
 openssl version
 
 # Installing python3
-# yum install gcc openssl-devel bzip2-devel libffi-devel -y
-# curl -O https://www.python.org/ftp/python/3.9.15/Python-3.9.15.tgz
-# if [ "$rc" != "0" ]; then
-#   failure_msg="[ERROR] Couldn't download python3."
-#   cfn_init_status
-# fi
-# tar -xzf Python-3.9.15.tgz
-# rm -rf Python-3.9.15.tgz
-# cd Python-3.9.15/
-# ./configure --enable-optimizations
-# cd ..
-# mv Python-3.9.15/ /usr/local/bin/python3
-yum install -y python3
+yum install gcc openssl-devel bzip2-devel libffi-devel -y
+curl -O https://www.python.org/ftp/python/3.10.8/Python-3.10.8.tgz
+if [ "$rc" != "0" ]; then
+  failure_msg="[ERROR] Couldn't download python3."
+  cfn_init_status
+fi
+tar -xzf Python-3.10.8.tgz
+rm -rf Python-3.10.8.tgz
+cd Python-3.10.8/
+./configure --prefix=/opt/python3 --enable-optimizations
+make
+make altinstall
+ln -s /opt/python3/bin/python3 /usr/bin/python3
+python3 --version
+# yum install -y python3
 
 # Install pyyaml
 pip3 install pyyaml

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -39,34 +39,6 @@ if [ ! -d "/usr/local/bin/" ]; then
   fi
 fi
 
-# Installing Red Hat Openshift 4.8 CLI
-# qs_retry_command 10 wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.8/openshift-client-linux.tar.gz
-# rc=$?
-# if [ "$rc" != "0" ]; then
-#   failure_msg="[ERROR] Couldn't download Red Hat OpenShift CLI file."
-#   cfn_init_status
-# fi
-# tar -xvf openshift-client-linux.tar.gz
-# chmod -R 755 oc
-# chmod -R 755 kubectl
-# mv oc /usr/local/bin/oc
-# mv kubectl /usr/local/bin/kubectl
-# rm -f openshift-client-linux.tar.gz
-
-# Installing Red Hat Openshift 4.8 installer
-# wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.8/openshift-install-linux.tar.gz
-# rc=$?
-# if [ "$rc" != "0" ]; then
-#   failure_msg="[ERROR] Couldn't download Red Hat OpenShift installer file."
-#   cfn_init_status
-# fi
-# tar -xvf openshift-install-linux.tar.gz
-# chmod 755 openshift-install
-# mv openshift-install /ibm
-# rm -f openshift-install-linux.tar.gz
-
-# cd ..
-
 # Installing Red Hat Openshift 4.10 CLI
 qs_retry_command 10 wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.10/openshift-client-linux.tar.gz
 rc=$?
@@ -140,6 +112,27 @@ make install
 echo -e "export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64" >> /etc/profile.d/openssl.sh
 source /etc/profile.d/openssl.sh
 openssl version
+
+# Installing python3
+# yum install gcc openssl-devel bzip2-devel libffi-devel -y
+# curl -O https://www.python.org/ftp/python/3.9.15/Python-3.9.15.tgz
+# if [ "$rc" != "0" ]; then
+#   failure_msg="[ERROR] Couldn't download python3."
+#   cfn_init_status
+# fi
+# tar -xzf Python-3.9.15.tgz
+# rm -rf Python-3.9.15.tgz
+# cd Python-3.9.15/
+# ./configure --enable-optimizations
+# cd ..
+# mv Python-3.9.15/ /usr/local/bin/python3
+yum install -y python3
+
+# Install pyyaml
+pip3 install pyyaml
+
+# Install Argparse
+pip3 install argparse
 
 # Installing jq
 yum install wget

--- a/scripts/gi_install.py
+++ b/scripts/gi_install.py
@@ -727,7 +727,8 @@ class GuardiumInsightsInstall(object):
         try:
             data = "%s: IBM Security Guardium Insights installation elapsed time: %d:%02d:%02d" % (status, eth, etm, ets)
             check_call([
-                'cfn-signal',
+                'python2',
+                '/bin/cfn-signal',
                 '--success', success,
                 '--id', self.stack_id,
                 '--reason', status,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,8 +16,8 @@ export ADMIN_PASSWORD=$6
 export DB2_SIZE=$7
 export TAINT_DATA_NODE=$8
 export CP_REPO_PASS=$9
-export GI_VERSION=$10
-export GI_PRODUCTION_SIZE=$11
+export GI_VERSION=${10}
+export GI_PRODUCTION_SIZE=${11}
 
 if [ $GI_VERSION == "3.2.0" ]; then
   export CASE_VERSION="2.2.0"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,8 +16,8 @@ export ADMIN_PASSWORD=$6
 export DB2_SIZE=$7
 export TAINT_DATA_NODE=$8
 export CP_REPO_PASS=$9
-export GI_VERSION=${10}
-export GI_PRODUCTION_SIZE=${11}
+export GI_VERSION=$10
+export GI_PRODUCTION_SIZE=$11
 
 if [ $GI_VERSION == "3.2.0" ]; then
   export CASE_VERSION="2.2.0"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,12 +19,12 @@ export CP_REPO_PASS=$9
 export GI_VERSION=${10}
 export GI_PRODUCTION_SIZE=${11}
 
-if [ "$GI_VERSION" == "3.2.0" ]]; then
-  export CASE_VERSION="2.2.0"
-  export CASE_ARCHIVE="ibm-guardium-insights-2.2.0.tgz"
-elif [ "$GI_VERSION" == "3.2.1" ]; then
+if [ "$GI_VERSION" == "3.2.1" ]]; then
   export CASE_VERSION="2.2.1"
   export CASE_ARCHIVE="ibm-guardium-insights-2.2.1.tgz"
+elif [ "$GI_VERSION" == "3.2.2" ]; then
+  export CASE_VERSION="2.2.2"
+  export CASE_ARCHIVE="ibm-guardium-insights-2.2.2.tgz"
 else
   echo "IBM Security Guardium Insights Version not supported. Exiting..."
   exit 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,10 +19,10 @@ export CP_REPO_PASS=$9
 export GI_VERSION=${10}
 export GI_PRODUCTION_SIZE=${11}
 
-if [ $GI_VERSION == "3.2.0" ]; then
+if [ "$GI_VERSION" == "3.2.0" ]]; then
   export CASE_VERSION="2.2.0"
   export CASE_ARCHIVE="ibm-guardium-insights-2.2.0.tgz"
-elif [ $GI_VERSION == "3.2.1" ]; then
+elif [ "$GI_VERSION" == "3.2.1" ]; then
   export CASE_VERSION="2.2.1"
   export CASE_ARCHIVE="ibm-guardium-insights-2.2.1.tgz"
 else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -285,6 +285,7 @@ cloudctl case launch \
   --namespace openshift-marketplace \
   --inventory install \
   --action install-catalog \
+  --args "--inputDir ${LOCAL_CASE_DIR}" \
   --tolerance 1
 # Checking exit status
 rc=$?

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,12 +19,12 @@ export CP_REPO_PASS=$9
 export GI_VERSION=${10}
 export GI_PRODUCTION_SIZE=${11}
 
-if [ $GI_VERSION == "3.1.10" ]; then
-  export CASE_VERSION="2.1.10"
-  export CASE_ARCHIVE="ibm-guardium-insights-2.1.10.tgz"
-elif [ $GI_VERSION == "3.1.11" ]; then
-  export CASE_VERSION="2.1.11"
-  export CASE_ARCHIVE="ibm-guardium-insights-2.1.11.tgz"
+if [ $GI_VERSION == "3.2.0" ]; then
+  export CASE_VERSION="2.2.0"
+  export CASE_ARCHIVE="ibm-guardium-insights-2.2.0.tgz"
+elif [ $GI_VERSION == "3.2.1" ]; then
+  export CASE_VERSION="2.2.1"
+  export CASE_ARCHIVE="ibm-guardium-insights-2.1.1.tgz"
 else
   echo "IBM Security Guardium Insights Version not supported. Exiting..."
   exit 1
@@ -101,7 +101,7 @@ cloudctl case launch \
   --inventory ibmCommonServiceOperatorSetup \
   --action install-catalog \
   --tolerance 1 \
-  --args "--registry icr.io"
+  --args "--registry icr.io --inputDir ${LOCAL_CASE_DIR}"
 # Checking exit status
 rc=$?
 if [ "$rc" != "0" ]; then
@@ -168,7 +168,7 @@ cloudctl case launch \
   --inventory ibmCommonServiceOperatorSetup \
   --tolerance 1 \
   --action install-operator \
-  --args "--size ${ICS_SIZE}"
+  --args "--size ${ICS_SIZE} --inputDir ${LOCAL_CASE_DIR}"
 # Checking exit status
 rc=$?
 if [ "$rc" != "0" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,7 +24,7 @@ if [ $GI_VERSION == "3.2.0" ]; then
   export CASE_ARCHIVE="ibm-guardium-insights-2.2.0.tgz"
 elif [ $GI_VERSION == "3.2.1" ]; then
   export CASE_VERSION="2.2.1"
-  export CASE_ARCHIVE="ibm-guardium-insights-2.1.1.tgz"
+  export CASE_ARCHIVE="ibm-guardium-insights-2.2.1.tgz"
 else
   echo "IBM Security Guardium Insights Version not supported. Exiting..."
   exit 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,7 +19,7 @@ export CP_REPO_PASS=$9
 export GI_VERSION=${10}
 export GI_PRODUCTION_SIZE=${11}
 
-if [ "$GI_VERSION" == "3.2.1" ]]; then
+if [ "$GI_VERSION" == "3.2.1" ]; then
   export CASE_VERSION="2.2.1"
   export CASE_ARCHIVE="ibm-guardium-insights-2.2.1.tgz"
 elif [ "$GI_VERSION" == "3.2.2" ]; then

--- a/scripts/templates/ocs/deploy-with-olm.yaml
+++ b/scripts/templates/ocs/deploy-with-olm.yaml
@@ -25,7 +25,7 @@ metadata:
   name: ocs-operator
   namespace: openshift-storage
 spec:
-  channel: stable-4.8
+  channel: stable-4.10
   installPlanApproval: Automatic
   name: ocs-operator
   source: redhat-operators

--- a/scripts/templates/ocs/ocs-storagecluster.yaml
+++ b/scripts/templates/ocs/ocs-storagecluster.yaml
@@ -36,4 +36,4 @@ spec:
       replica: 3
       portable: true
       preparePlacement: {}
-  version: 4.8.0
+  version: 4.10.0

--- a/templates/ibm-security-guardium-insights.template.yaml
+++ b/templates/ibm-security-guardium-insights.template.yaml
@@ -821,7 +821,7 @@ Resources:
             source $P
             qs_bootstrap_pip || qs_err " pip bootstrap failed "
             qs_aws-cfn-bootstrap || qs_err " cfn bootstrap failed "
-            pip install awscli  &> /var/log/userdata.awscli_install.log || qs_err " awscli install failed "
+            pip3 install awscli  &> /var/log/userdata.awscli_install.log || qs_err " awscli install failed "
             /usr/bin/cfn-init -v --stack ${AWS::StackName} --resource BootnodeInstance --configsets Required --region ${AWS::Region}
             # Signal the status from cfn-init
             /usr/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource BootnodeInstance --region ${AWS::Region}

--- a/templates/ibm-security-guardium-insights.template.yaml
+++ b/templates/ibm-security-guardium-insights.template.yaml
@@ -302,12 +302,12 @@ Parameters:
     Type: String
   LicenseType:
     AllowedValues:
-      - 'L-TESX-CF9NUW - IBM  Security Guardium Insights v3.2'
-      - 'L-TESX-CF9NVW - IBM Security Guardium Insights for Guardium Data Protection for z/OS v3.2'
-      - 'L-TESX-CF9NWS - IBM Security Guardium Insights for IBM Cloud Pak for Security v3.2'
-      - 'L-GBLK-CDVHGZ - IBM Security Guardium Package (Software) v1.10'
-      - 'L-GBLK-CEYGU9 - IBM Cloud Pak for Security (Gen 3) v1.10 (Replaces IBM Security Guardium Insights for IBM Cloud Pak for Security 3.1)'
-    Default: 'L-GBLK-CDVHGZ - IBM Security Guardium Package (Software) v1.10'
+      - 'L-TESX-CF9NUW (IBM  Security Guardium Insights v3.2)'
+      - 'L-TESX-CF9NVW (IBM Security Guardium Insights for Guardium Data Protection for z/OS v3.2)'
+      - 'L-TESX-CF9NWS (IBM Security Guardium Insights for IBM Cloud Pak for Security v3.2)'
+      - 'L-GBLK-CDVHGZ (IBM Security Guardium Package (Software) v1.10)'
+      - 'L-GBLK-CEYGU9 (IBM Cloud Pak for Security (Gen 3) v1.10 (Replaces IBM Security Guardium Insights for IBM Cloud Pak for Security 3.1))'
+    Default: 'L-GBLK-CDVHGZ (IBM Security Guardium Package (Software) v1.10)'
     Description: IBM Security Guardium Insights license types.
     Type: String
   GIVersion:

--- a/templates/ibm-security-guardium-insights.template.yaml
+++ b/templates/ibm-security-guardium-insights.template.yaml
@@ -307,7 +307,7 @@ Parameters:
       - 'L-TESX-CF9NWS - IBM Security Guardium Insights for IBM Cloud Pak for Security v3.2'
       - 'L-GBLK-CDVHGZ - IBM Security Guardium Package (Software) v1.10'
       - 'L-GBLK-CEYGU9 - IBM Cloud Pak for Security (Gen 3) v1.10 (Replaces IBM Security Guardium Insights for IBM Cloud Pak for Security 3.1)'
-    Default: 'L-GBLK-CDVHGZ (IBM Security Guardium Package (Software) v1.10)'
+    Default: 'L-GBLK-CDVHGZ - IBM Security Guardium Package (Software) v1.10'
     Description: IBM Security Guardium Insights license types.
     Type: String
   GIVersion:

--- a/templates/ibm-security-guardium-insights.template.yaml
+++ b/templates/ibm-security-guardium-insights.template.yaml
@@ -302,18 +302,19 @@ Parameters:
     Type: String
   LicenseType:
     AllowedValues:
-      - 'L-TESX-C86NC4 (IBM Security Guardium Insights for IBM Cloud Pak for Security (Gen 3))'
-      - 'L-TESX-C86NKZ (IBM Security Guardium Insights)'
-      - 'L-TESX-C86NM4 (IBM Security Guardium Insights for Guardium Data Protection for z/OS)'
-      - 'L-TESX-C86NPQ (IBM Security Guardium Insights for IBM Cloud Pak for Security)'
-    Default: 'L-TESX-C86NC4 (IBM Security Guardium Insights for IBM Cloud Pak for Security (Gen 3))'
+      - 'L-TESX-CF9NUW - IBM  Security Guardium Insights v3.2'
+      - 'L-TESX-CF9NVW - IBM Security Guardium Insights for Guardium Data Protection for z/OS v3.2'
+      - 'L-TESX-CF9NWS - IBM Security Guardium Insights for IBM Cloud Pak for Security v3.2'
+      - 'L-GBLK-CDVHGZ - IBM Security Guardium Package (Software) v1.10'
+      - 'L-GBLK-CEYGU9 - IBM Cloud Pak for Security (Gen 3) v1.10 (Replaces IBM Security Guardium Insights for IBM Cloud Pak for Security 3.1)'
+    Default: 'L-GBLK-CDVHGZ (IBM Security Guardium Package (Software) v1.10)'
     Description: IBM Security Guardium Insights license types.
     Type: String
   GIVersion:
     AllowedValues:
-      - '3.1.10'
-      - '3.1.11'
-    Default: '3.1.11'
+      - '3.2.0'
+      - '3.2.1'
+    Default: '3.2.1'
     Description: Version of IBM Security Guardium Insights to be deployed.
     Type: String
   Namespace:

--- a/templates/ibm-security-guardium-insights.template.yaml
+++ b/templates/ibm-security-guardium-insights.template.yaml
@@ -312,9 +312,9 @@ Parameters:
     Type: String
   GIVersion:
     AllowedValues:
-      - '3.2.0'
       - '3.2.1'
-    Default: '3.2.1'
+      - '3.2.2'
+    Default: '3.2.2'
     Description: Version of IBM Security Guardium Insights to be deployed.
     Type: String
   Namespace:

--- a/templates/ibm-security-guardium-insights.template.yaml
+++ b/templates/ibm-security-guardium-insights.template.yaml
@@ -302,13 +302,11 @@ Parameters:
     Type: String
   LicenseType:
     AllowedValues:
-      - 'L-TESX-CF9NUW (IBM  Security Guardium Insights v3.2)'
-      - 'L-TESX-CF9NVW (IBM Security Guardium Insights for Guardium Data Protection for z/OS v3.2)'
-      - 'L-TESX-CF9NWS (IBM Security Guardium Insights for IBM Cloud Pak for Security v3.2)'
-      - 'L-GBLK-CDVHGZ (IBM Security Guardium Package (Software) v1.10)'
-      - 'L-GBLK-CEYGU9 (IBM Cloud Pak for Security (Gen 3) v1.10 (Replaces IBM Security Guardium Insights for IBM Cloud Pak for Security 3.1))'
-    Default: 'L-GBLK-CDVHGZ (IBM Security Guardium Package (Software) v1.10)'
-    Description: IBM Security Guardium Insights license types.
+      - 'IBM Security Guardium Package (Software) (L-GBLK-CDVHGZ)'
+      - 'IBM Security Guardium Insights for IBM Cloud Pak for Security (Gen 3) (L-TESX-C86NC4)'
+      - 'IBM Security Guardium Insights for IBM Cloud Pak for Security (L-TESX-C86NPQ)'
+    Default: 'IBM Security Guardium Package (Software) (L-GBLK-CDVHGZ)'
+    Description: IBM Security Guardium Insights license types, confirm entitled part name in IBM-provided Proof of Entitlement.
     Type: String
   GIVersion:
     AllowedValues:

--- a/templates/ibm-security-root.template.yaml
+++ b/templates/ibm-security-root.template.yaml
@@ -293,13 +293,11 @@ Parameters:
     Type: String
   LicenseType:
     AllowedValues:
-      - 'L-TESX-CF9NUW (IBM  Security Guardium Insights v3.2)'
-      - 'L-TESX-CF9NVW (IBM Security Guardium Insights for Guardium Data Protection for z/OS v3.2)'
-      - 'L-TESX-CF9NWS (IBM Security Guardium Insights for IBM Cloud Pak for Security v3.2)'
-      - 'L-GBLK-CDVHGZ (IBM Security Guardium Package (Software) v1.10)'
-      - 'L-GBLK-CEYGU9 (IBM Cloud Pak for Security (Gen 3) v1.10 (Replaces IBM Security Guardium Insights for IBM Cloud Pak for Security 3.1))'
-    Default: 'L-GBLK-CDVHGZ (IBM Security Guardium Package (Software) v1.10)'
-    Description: IBM Security Guardium Insights license types.
+      - 'IBM Security Guardium Package (Software) (L-GBLK-CDVHGZ)'
+      - 'IBM Security Guardium Insights for IBM Cloud Pak for Security (Gen 3) (L-TESX-C86NC4)'
+      - 'IBM Security Guardium Insights for IBM Cloud Pak for Security (L-TESX-C86NPQ)'
+    Default: 'IBM Security Guardium Package (Software) (L-GBLK-CDVHGZ)'
+    Description: IBM Security Guardium Insights license types, confirm entitled part name in IBM-provided Proof of Entitlement.
     Type: String
   GIVersion:
     AllowedValues:

--- a/templates/ibm-security-root.template.yaml
+++ b/templates/ibm-security-root.template.yaml
@@ -303,9 +303,9 @@ Parameters:
     Type: String
   GIVersion:
     AllowedValues:
-      - '3.2.0'
       - '3.2.1'
-    Default: '3.2.1'
+      - '3.2.2'
+    Default: '3.2.2'
     Description: Version of IBM Security Guardium Insights to be deployed.
     Type: String
   Namespace:

--- a/templates/ibm-security-root.template.yaml
+++ b/templates/ibm-security-root.template.yaml
@@ -293,18 +293,19 @@ Parameters:
     Type: String
   LicenseType:
     AllowedValues:
-      - 'L-TESX-C86NC4 (IBM Security Guardium Insights for IBM Cloud Pak for Security (Gen 3))'
-      - 'L-TESX-C86NKZ (IBM Security Guardium Insights)'
-      - 'L-TESX-C86NM4 (IBM Security Guardium Insights for Guardium Data Protection for z/OS)'
-      - 'L-TESX-C86NPQ (IBM Security Guardium Insights for IBM Cloud Pak for Security)'
-    Default: 'L-TESX-C86NC4 (IBM Security Guardium Insights for IBM Cloud Pak for Security (Gen 3))'
+      - 'L-TESX-CF9NUW - IBM  Security Guardium Insights v3.2'
+      - 'L-TESX-CF9NVW - IBM Security Guardium Insights for Guardium Data Protection for z/OS v3.2'
+      - 'L-TESX-CF9NWS - IBM Security Guardium Insights for IBM Cloud Pak for Security v3.2'
+      - 'L-GBLK-CDVHGZ - IBM Security Guardium Package (Software) v1.10'
+      - 'L-GBLK-CEYGU9 - IBM Cloud Pak for Security (Gen 3) v1.10 (Replaces IBM Security Guardium Insights for IBM Cloud Pak for Security 3.1)'
+    Default: 'L-GBLK-CDVHGZ (IBM Security Guardium Package (Software) v1.10)'
     Description: IBM Security Guardium Insights license types.
     Type: String
   GIVersion:
     AllowedValues:
-      - '3.1.10'
-      - '3.1.11'
-    Default: '3.1.11'
+      - '3.2.0'
+      - '3.2.1'
+    Default: '3.2.1'
     Description: Version of IBM Security Guardium Insights to be deployed.
     Type: String
   Namespace:

--- a/templates/ibm-security-root.template.yaml
+++ b/templates/ibm-security-root.template.yaml
@@ -293,12 +293,12 @@ Parameters:
     Type: String
   LicenseType:
     AllowedValues:
-      - 'L-TESX-CF9NUW - IBM  Security Guardium Insights v3.2'
-      - 'L-TESX-CF9NVW - IBM Security Guardium Insights for Guardium Data Protection for z/OS v3.2'
-      - 'L-TESX-CF9NWS - IBM Security Guardium Insights for IBM Cloud Pak for Security v3.2'
-      - 'L-GBLK-CDVHGZ - IBM Security Guardium Package (Software) v1.10'
-      - 'L-GBLK-CEYGU9 - IBM Cloud Pak for Security (Gen 3) v1.10 (Replaces IBM Security Guardium Insights for IBM Cloud Pak for Security 3.1)'
-    Default: 'L-GBLK-CDVHGZ - IBM Security Guardium Package (Software) v1.10'
+      - 'L-TESX-CF9NUW (IBM  Security Guardium Insights v3.2)'
+      - 'L-TESX-CF9NVW (IBM Security Guardium Insights for Guardium Data Protection for z/OS v3.2)'
+      - 'L-TESX-CF9NWS (IBM Security Guardium Insights for IBM Cloud Pak for Security v3.2)'
+      - 'L-GBLK-CDVHGZ (IBM Security Guardium Package (Software) v1.10)'
+      - 'L-GBLK-CEYGU9 (IBM Cloud Pak for Security (Gen 3) v1.10 (Replaces IBM Security Guardium Insights for IBM Cloud Pak for Security 3.1))'
+    Default: 'L-GBLK-CDVHGZ (IBM Security Guardium Package (Software) v1.10)'
     Description: IBM Security Guardium Insights license types.
     Type: String
   GIVersion:

--- a/templates/ibm-security-root.template.yaml
+++ b/templates/ibm-security-root.template.yaml
@@ -298,7 +298,7 @@ Parameters:
       - 'L-TESX-CF9NWS - IBM Security Guardium Insights for IBM Cloud Pak for Security v3.2'
       - 'L-GBLK-CDVHGZ - IBM Security Guardium Package (Software) v1.10'
       - 'L-GBLK-CEYGU9 - IBM Cloud Pak for Security (Gen 3) v1.10 (Replaces IBM Security Guardium Insights for IBM Cloud Pak for Security 3.1)'
-    Default: 'L-GBLK-CDVHGZ (IBM Security Guardium Package (Software) v1.10)'
+    Default: 'L-GBLK-CDVHGZ - IBM Security Guardium Package (Software) v1.10'
     Description: IBM Security Guardium Insights license types.
     Type: String
   GIVersion:


### PR DESCRIPTION
This updates the Guardium Insights to our latest GI 3.2 Release
*Description of changes:*
Added extensive support for GI 3.2 and removed support for GI 3.1 from the Quickstart.

Taskcat output available here: https://babztest.s3.us-east-2.amazonaws.com/taskcat_outputs/

Please let me know if anything else is required @vsnyc 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
