### PR TITLE
Update IBM GI links to 3.2

### DIFF
--- a/docs/deployment_guide/partner_editable/pre_deployment.adoc
+++ b/docs/deployment_guide/partner_editable/pre_deployment.adoc
@@ -24,8 +24,8 @@ To create your own fully qualified domain name (FQDN) for the {partner-product-n
 . For *Routing policy*, choose `Simple routing`.
 . Choose *Create record*.
 
-Upload the TLS certificate, TLS key, and custom TLS certificate to the S3 bucket you created for your OpenShift pull secret. During deployment, enter the TLS certificate, TLS keys, and custom TLS certificate as parameters. For more information, refer to https://www.ibm.com/docs/en/guardium-insights/3.1.x?topic=planning-domain-name-tls-certificates[Domain Name and TLS Certificates^].
+Upload the TLS certificate, TLS key, and custom TLS certificate to the S3 bucket you created for your OpenShift pull secret. During deployment, enter the TLS certificate, TLS keys, and custom TLS certificate as parameters. For more information, refer to https://www.ibm.com/docs/SSWSZ5_3.2.x/planning/planning_domain_tls.html[Domain Name and TLS Certificates^].
 
 === Deployment sizes
 
-The Quick Start supports extra-small, small, medium, and large deployments of {partner-product-name} on the AWS Cloud. During deployment, specify a production size using the `IBM Security Guardium Insights production size` (`GIProductionSize`) parameter. For more information about the hardware requirements for different production sizes, refer to https://www.ibm.com/docs/en/guardium-insights/3.1.x?topic=planning-hardware-cluster-requirements[Hardware cluster requirements^].
+The Quick Start supports extra-small, small, medium, and large deployments of {partner-product-name} on the AWS Cloud. During deployment, specify a production size using the `IBM Security Guardium Insights production size` (`GIProductionSize`) parameter. For more information about the hardware requirements for different production sizes, refer to https://www.ibm.com/docs/SSWSZ5_3.2.x/planning/sys_req_hardware_cluster.html[Hardware cluster requirements^].

--- a/docs/deployment_guide/partner_editable/troubleshooting.adoc
+++ b/docs/deployment_guide/partner_editable/troubleshooting.adoc
@@ -5,7 +5,7 @@ The deployment generates the following standard output (stdout) log files in the
 * `gi_install.log` – Standard output of IBM Cloud Pak foundational services and IBM Security Guardium Insights installation, including installation validation.
 * `bootstrap.log` – Standard output of a high-level overview of events during deployment of Red Hat OpenShift Container Platform and IBM Security Guardium Insights.
 
-For troubleshooting {partner-product-name}, refer to https://www.ibm.com/docs/en/guardium-insights/3.1.x?topic=problems-techniques-troubleshooting[Techniques for troubleshooting problems^].
+For troubleshooting {partner-product-name}, refer to https://www.ibm.com/docs/SSWSZ5_3.2.x/tshoot/h2_overview.html[Techniques for troubleshooting problems^].
 
 For troubleshooting common Quick Start issues, refer to the https://fwd.aws/rA69w?[AWS Quick Starts General Information Guide^] and https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/troubleshooting.html[Troubleshooting CloudFormation^].
 


### PR DESCRIPTION
*Description of changes:*
This Pull Request updates the documentation in our QT deployment guide to correctly point to the version 3.2 and remove references to the old version 3.1 in the docs.

The new links were verified with asciidoctor as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
