### PR TITLE
Update deprecated cloudctl to oc ibm-pak

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -39,8 +39,8 @@ if [ ! -d "/usr/local/bin/" ]; then
   fi
 fi
 
-# Installing Red Hat Openshift 4.10 CLI
-qs_retry_command 10 wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.10/openshift-client-linux.tar.gz
+# Installing Red Hat Openshift 4.12 CLI
+qs_retry_command 10 wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.12/openshift-client-linux.tar.gz
 rc=$?
 if [ "$rc" != "0" ]; then
   failure_msg="[ERROR] Couldn't download Red Hat OpenShift CLI file."
@@ -53,8 +53,8 @@ mv oc /usr/local/bin/oc
 mv kubectl /usr/local/bin/kubectl
 rm -f openshift-client-linux.tar.gz
 
-# Installing Red Hat Openshift 4.10 installer
-wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.10/openshift-install-linux.tar.gz
+# Installing Red Hat Openshift 4.12 installer
+wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.12/openshift-install-linux.tar.gz
 rc=$?
 if [ "$rc" != "0" ]; then
   failure_msg="[ERROR] Couldn't download Red Hat OpenShift installer file."

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -122,30 +122,6 @@ if [ "$rc" != "0" ]; then
 fi
 chmod 755 /usr/local/bin/jq
 
-# Installing oc ibm-pak
-qs_retry_command 10 wget https://github.com/IBM/ibm-pak/releases/latest/download/oc-ibm_pak-linux-amd64.tar.gz
-rc=$?
-if [ "$rc" != "0" ]; then
-  failure_msg="[ERROR] Couldn't download oc ibm-pak."
-  cfn_init_status
-fi
-tar -xf oc-ibm_pak-linux-amd64.tar.gz
-chmod 755 oc-ibm_pak
-mv oc-ibm_pak-linux-amd64 /usr/local/bin/oc-ibm_pak
-rm -f oc-ibm_pak-linux-amd64.tar.gz
-
-# Installing casectl
-qs_retry_command 10 wget http://rchgsa.ibm.com/projects/c/cloud-prereq/casectl/latest/casectl-linux-amd64.tar.gz
-rc=$?
-if [ "$rc" != "0" ]; then
-  failure_msg="[ERROR] Couldn't download casectl."
-  cfn_init_status
-fi
-tar -xvzf casectl-linux-amd64.tar.gz
-chmod 755 casectl
-mv casectl /usr/local/bin/casectl
-rm -f casectl-linux-amd64.tar.gz
-
 # Installing yq
 wget https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_386 -O /usr/local/bin/yq
 if [ "$rc" != "0" ]; then

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -122,6 +122,30 @@ if [ "$rc" != "0" ]; then
 fi
 chmod 755 /usr/local/bin/jq
 
+# Installing oc ibm-pak
+qs_retry_command 10 wget https://github.com/IBM/ibm-pak/releases/latest/download/oc-ibm_pak-linux-amd64.tar.gz
+rc=$?
+if [ "$rc" != "0" ]; then
+  failure_msg="[ERROR] Couldn't download oc ibm-pak."
+  cfn_init_status
+fi
+tar -xf oc-ibm_pak-linux-amd64.tar.gz
+chmod 755 oc-ibm_pak
+mv oc-ibm_pak-linux-amd64 /usr/local/bin/oc-ibm_pak
+rm -f oc-ibm_pak-linux-amd64.tar.gz
+
+# Installing casectl
+qs_retry_command 10 wget http://rchgsa.ibm.com/projects/c/cloud-prereq/casectl/latest/casectl-linux-amd64.tar.gz
+rc=$?
+if [ "$rc" != "0" ]; then
+  failure_msg="[ERROR] Couldn't download casectl."
+  cfn_init_status
+fi
+tar -xvzf casectl-linux-amd64.tar.gz
+chmod 755 casectl
+mv casectl /usr/local/bin/casectl
+rm -f casectl-linux-amd64.tar.gz
+
 # Installing yq
 wget https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_386 -O /usr/local/bin/yq
 if [ "$rc" != "0" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,14 +18,13 @@ export TAINT_DATA_NODE=$8
 export CP_REPO_PASS=$9
 export GI_VERSION=${10}
 export GI_PRODUCTION_SIZE=${11}
-export CASE_NAME=ibm-guardium-insights
 
-if [ "$GI_VERSION" == "3.2.8" ]; then
-  export CASE_VERSION="2.2.8"
-  export CASE_ARCHIVE="ibm-guardium-insights-2.2.8.tgz"
-elif [ "$GI_VERSION" == "3.2.7" ]; then
+if [ "$GI_VERSION" == "3.2.7" ]; then
   export CASE_VERSION="2.2.7"
   export CASE_ARCHIVE="ibm-guardium-insights-2.2.7.tgz"
+elif [ "$GI_VERSION" == "3.2.6" ]; then
+  export CASE_VERSION="2.2.6"
+  export CASE_ARCHIVE="ibm-guardium-insights-2.2.6.tgz"
 else
   echo "IBM Security Guardium Insights Version not supported. Exiting..."
   exit 1
@@ -74,12 +73,9 @@ check_exit_status
 echo "------------------------------------------------------"
 echo "DOWNLOADING AND EXTRACTING GUARDIUM INSIGHTS CASE FILE"
 echo "------------------------------------------------------"
-# cloudctl case save \
-#   --case https://github.com/IBM/cloud-pak/raw/master/repo/case/ibm-guardium-insights/${CASE_VERSION}/${CASE_ARCHIVE} \
-#   --outputdir $LOCAL_CASE_DIR --tolerance 1
-oc ibm-pak get $CASE_NAME \
---version $CASE_VERSION \
---skip-verify
+cloudctl case save \
+  --case https://github.com/IBM/cloud-pak/raw/master/repo/case/ibm-guardium-insights/${CASE_VERSION}/${CASE_ARCHIVE} \
+  --outputdir $LOCAL_CASE_DIR --tolerance 1
 # Checking exit status
 rc=$?
 success_msg="[SUCCESS] Download and extracted IBM Security Guardium Insights CASE."
@@ -99,20 +95,13 @@ check_exit_status
 echo "--------------------------------------------------"
 echo "INSTALLING CLOUD PAK FOUNDATIONAL SERVICES CATALOG"
 echo "--------------------------------------------------"
-# cloudctl case launch \
-#   --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
-#   --namespace $ICS_NAMESPACE \
-#   --inventory ibmCommonServiceOperatorSetup \
-#   --action install-catalog \
-#   --tolerance 1 \
-#   --args "--registry icr.io --inputDir ${LOCAL_CASE_DIR}"
-oc ibm-pak launch $CASE_NAME \
-  --version ${CASE_VERSION} \
-  --action install-catalog \
+cloudctl case launch \
+  --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
+  --namespace $ICS_NAMESPACE \
   --inventory ibmCommonServiceOperatorSetup \
-  --namespace ${ICS_NAMESPACE} \
-  --args "--registry icr.io --recursive \
-  --inputDir ${LOCAL_CASE_DIR}"
+  --action install-catalog \
+  --tolerance 1 \
+  --args "--registry icr.io --inputDir ${LOCAL_CASE_DIR}"
 # Checking exit status
 rc=$?
 if [ "$rc" != "0" ]; then
@@ -173,19 +162,13 @@ done
 echo "----------------------------------------------------"
 echo "INSTALLING CLOUD PAK FOUNDATIONAL SERVICES OPERATORS"
 echo "----------------------------------------------------"
-# cloudctl case launch \
-#   --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
-#   --namespace ${ICS_NAMESPACE} \
-#   --inventory ibmCommonServiceOperatorSetup \
-#   --tolerance 1 \
-#   --action install-operator \
-#   --args "--size ${ICS_SIZE} --inputDir ${LOCAL_CASE_DIR}"
-oc ibm-pak launch $CASE_NAME \
-   --version ${CASE_VERSION} \
-   --inventory ibmCommonServiceOperatorSetup \
-   --action install-operator \
-   --namespace ${ICS_NAMESPACE} \
-   --args "--size ${ICS_SIZE} --inputDir ${LOCAL_CASE_DIR}"
+cloudctl case launch \
+  --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
+  --namespace ${ICS_NAMESPACE} \
+  --inventory ibmCommonServiceOperatorSetup \
+  --tolerance 1 \
+  --action install-operator \
+  --args "--size ${ICS_SIZE} --inputDir ${LOCAL_CASE_DIR}"
 # Checking exit status
 rc=$?
 if [ "$rc" != "0" ]; then
@@ -280,20 +263,13 @@ fi
 echo "------------------------------------------------------------"
 echo "INSTALLING GUARDIUM INSIGHTS OPERATOR AND RELATED COMPONENTS"
 echo "------------------------------------------------------------"
-# cloudctl case launch    \
-#   --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
-#   --namespace ${NAMESPACE} \
-#   --inventory install     \
-#   --action pre-install    \
-#   --tolerance 1 \
-#   --args "-n ${NAMESPACE} -h ${db2_data_nodes_list} -l true -t ${TAINT_DATA_NODE} -k ${INGRESS_KEYFILE} -f ${INGRESS_CERTFILE} -c ${INGRESS_CAFILE}"
-
-oc ibm-pak launch ${CASE_NAME} \
-   --version ${CASE_VERSION} \
-   --inventory install \
-   --action pre-install \
-   --namespace ${NAMESPACE} \
-   --args "-n ${NAMESPACE} -h ${db2_data_nodes_list} -l true -t ${TAINT_DATA_NODE} -k ${INGRESS_KEYFILE} -f ${INGRESS_CERTFILE} -c ${INGRESS_CAFILE}"
+cloudctl case launch    \
+  --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
+  --namespace ${NAMESPACE} \
+  --inventory install     \
+  --action pre-install    \
+  --tolerance 1 \
+  --args "-n ${NAMESPACE} -h ${db2_data_nodes_list} -l true -t ${TAINT_DATA_NODE} -k ${INGRESS_KEYFILE} -f ${INGRESS_CERTFILE} -c ${INGRESS_CAFILE}"
 # Checking exit status
 rc=$?
 success_msg="[SUCCESS] Installed the Guardium Insights operator and related components."
@@ -304,19 +280,13 @@ check_exit_status
 echo "-------------------------------------"
 echo "INSTALLING GUARDIUM INSIGHTS CATALOGS"
 echo "-------------------------------------"
-# cloudctl case launch \
-#   --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
-#   --namespace openshift-marketplace \
-#   --inventory install \
-#   --action install-catalog \
-#   --args "--inputDir ${LOCAL_CASE_DIR}" \
-#   --tolerance 1
-oc ibm-pak launch $CASE_NAME \
-   --version $CASE_VERSION \
-   --inventory install \
-   --action install-catalog \
-   --namespace openshift-marketplace \
-   --args "--inputDir ${LOCAL_CASE_DIR}"
+cloudctl case launch \
+  --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
+  --namespace openshift-marketplace \
+  --inventory install \
+  --action install-catalog \
+  --args "--inputDir ${LOCAL_CASE_DIR}" \
+  --tolerance 1
 # Checking exit status
 rc=$?
 if [ "$rc" != "0" ]; then
@@ -357,20 +327,13 @@ done
 echo "--------------------------------------"
 echo "INSTALLING GUARDIUM INSIGHTS OPERATORS"
 echo "--------------------------------------"
-# cloudctl case launch \
-#   --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
-#   --namespace ${NAMESPACE} \
-#   --inventory install \
-#   --action install-operator \
-#   --tolerance 1 \
-#   --args "--registry cp.icr.io --user ${CP_REPO_USER} --pass ${CP_REPO_PASS} --secret ibm-entitlement-key"
-
-oc ibm-pak launch ${CASE_NAME} \
-   --version ${CASE_VERSION} \
-   --inventory install \
-   --action install-operator \
-   --namespace ${NAMESPACE} \
-   --args "--registry cp.icr.io --user ${CP_REPO_USER} --pass ${CP_REPO_PASS} --secret ibm-entitlement-key --inputDir ${LOCAL_CASE_DIR}"
+cloudctl case launch \
+  --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
+  --namespace ${NAMESPACE} \
+  --inventory install \
+  --action install-operator \
+  --tolerance 1 \
+  --args "--registry cp.icr.io --user ${CP_REPO_USER} --pass ${CP_REPO_PASS} --secret ibm-entitlement-key"
 # Checking exit status
 rc=$?
 if [ "$rc" != "0" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,13 +18,14 @@ export TAINT_DATA_NODE=$8
 export CP_REPO_PASS=$9
 export GI_VERSION=${10}
 export GI_PRODUCTION_SIZE=${11}
+export CASE_NAME=ibm-guardium-insights
 
-if [ "$GI_VERSION" == "3.2.7" ]; then
+if [ "$GI_VERSION" == "3.2.8" ]; then
+  export CASE_VERSION="2.2.8"
+  export CASE_ARCHIVE="ibm-guardium-insights-2.2.8.tgz"
+elif [ "$GI_VERSION" == "3.2.7" ]; then
   export CASE_VERSION="2.2.7"
   export CASE_ARCHIVE="ibm-guardium-insights-2.2.7.tgz"
-elif [ "$GI_VERSION" == "3.2.6" ]; then
-  export CASE_VERSION="2.2.6"
-  export CASE_ARCHIVE="ibm-guardium-insights-2.2.6.tgz"
 else
   echo "IBM Security Guardium Insights Version not supported. Exiting..."
   exit 1
@@ -73,9 +74,12 @@ check_exit_status
 echo "------------------------------------------------------"
 echo "DOWNLOADING AND EXTRACTING GUARDIUM INSIGHTS CASE FILE"
 echo "------------------------------------------------------"
-cloudctl case save \
-  --case https://github.com/IBM/cloud-pak/raw/master/repo/case/ibm-guardium-insights/${CASE_VERSION}/${CASE_ARCHIVE} \
-  --outputdir $LOCAL_CASE_DIR --tolerance 1
+# cloudctl case save \
+#   --case https://github.com/IBM/cloud-pak/raw/master/repo/case/ibm-guardium-insights/${CASE_VERSION}/${CASE_ARCHIVE} \
+#   --outputdir $LOCAL_CASE_DIR --tolerance 1
+oc ibm-pak get $CASE_NAME \
+--version $CASE_VERSION \
+--skip-verify
 # Checking exit status
 rc=$?
 success_msg="[SUCCESS] Download and extracted IBM Security Guardium Insights CASE."
@@ -95,13 +99,20 @@ check_exit_status
 echo "--------------------------------------------------"
 echo "INSTALLING CLOUD PAK FOUNDATIONAL SERVICES CATALOG"
 echo "--------------------------------------------------"
-cloudctl case launch \
-  --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
-  --namespace $ICS_NAMESPACE \
-  --inventory ibmCommonServiceOperatorSetup \
+# cloudctl case launch \
+#   --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
+#   --namespace $ICS_NAMESPACE \
+#   --inventory ibmCommonServiceOperatorSetup \
+#   --action install-catalog \
+#   --tolerance 1 \
+#   --args "--registry icr.io --inputDir ${LOCAL_CASE_DIR}"
+oc ibm-pak launch $CASE_NAME \
+  --version ${CASE_VERSION} \
   --action install-catalog \
-  --tolerance 1 \
-  --args "--registry icr.io --inputDir ${LOCAL_CASE_DIR}"
+  --inventory ibmCommonServiceOperatorSetup \
+  --namespace ${ICS_NAMESPACE} \
+  --args "--registry icr.io --recursive \
+  --inputDir ${LOCAL_CASE_DIR}"
 # Checking exit status
 rc=$?
 if [ "$rc" != "0" ]; then
@@ -162,13 +173,19 @@ done
 echo "----------------------------------------------------"
 echo "INSTALLING CLOUD PAK FOUNDATIONAL SERVICES OPERATORS"
 echo "----------------------------------------------------"
-cloudctl case launch \
-  --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
-  --namespace ${ICS_NAMESPACE} \
-  --inventory ibmCommonServiceOperatorSetup \
-  --tolerance 1 \
-  --action install-operator \
-  --args "--size ${ICS_SIZE} --inputDir ${LOCAL_CASE_DIR}"
+# cloudctl case launch \
+#   --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
+#   --namespace ${ICS_NAMESPACE} \
+#   --inventory ibmCommonServiceOperatorSetup \
+#   --tolerance 1 \
+#   --action install-operator \
+#   --args "--size ${ICS_SIZE} --inputDir ${LOCAL_CASE_DIR}"
+oc ibm-pak launch $CASE_NAME \
+   --version ${CASE_VERSION} \
+   --inventory ibmCommonServiceOperatorSetup \
+   --action install-operator \
+   --namespace ${ICS_NAMESPACE} \
+   --args "--size ${ICS_SIZE} --inputDir ${LOCAL_CASE_DIR}"
 # Checking exit status
 rc=$?
 if [ "$rc" != "0" ]; then
@@ -263,13 +280,20 @@ fi
 echo "------------------------------------------------------------"
 echo "INSTALLING GUARDIUM INSIGHTS OPERATOR AND RELATED COMPONENTS"
 echo "------------------------------------------------------------"
-cloudctl case launch    \
-  --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
-  --namespace ${NAMESPACE} \
-  --inventory install     \
-  --action pre-install    \
-  --tolerance 1 \
-  --args "-n ${NAMESPACE} -h ${db2_data_nodes_list} -l true -t ${TAINT_DATA_NODE} -k ${INGRESS_KEYFILE} -f ${INGRESS_CERTFILE} -c ${INGRESS_CAFILE}"
+# cloudctl case launch    \
+#   --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
+#   --namespace ${NAMESPACE} \
+#   --inventory install     \
+#   --action pre-install    \
+#   --tolerance 1 \
+#   --args "-n ${NAMESPACE} -h ${db2_data_nodes_list} -l true -t ${TAINT_DATA_NODE} -k ${INGRESS_KEYFILE} -f ${INGRESS_CERTFILE} -c ${INGRESS_CAFILE}"
+
+oc ibm-pak launch ${CASE_NAME} \
+   --version ${CASE_VERSION} \
+   --inventory install \
+   --action pre-install \
+   --namespace ${NAMESPACE} \
+   --args "-n ${NAMESPACE} -h ${db2_data_nodes_list} -l true -t ${TAINT_DATA_NODE} -k ${INGRESS_KEYFILE} -f ${INGRESS_CERTFILE} -c ${INGRESS_CAFILE}"
 # Checking exit status
 rc=$?
 success_msg="[SUCCESS] Installed the Guardium Insights operator and related components."
@@ -280,13 +304,19 @@ check_exit_status
 echo "-------------------------------------"
 echo "INSTALLING GUARDIUM INSIGHTS CATALOGS"
 echo "-------------------------------------"
-cloudctl case launch \
-  --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
-  --namespace openshift-marketplace \
-  --inventory install \
-  --action install-catalog \
-  --args "--inputDir ${LOCAL_CASE_DIR}" \
-  --tolerance 1
+# cloudctl case launch \
+#   --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
+#   --namespace openshift-marketplace \
+#   --inventory install \
+#   --action install-catalog \
+#   --args "--inputDir ${LOCAL_CASE_DIR}" \
+#   --tolerance 1
+oc ibm-pak launch $CASE_NAME \
+   --version $CASE_VERSION \
+   --inventory install \
+   --action install-catalog \
+   --namespace openshift-marketplace \
+   --args "--inputDir ${LOCAL_CASE_DIR}"
 # Checking exit status
 rc=$?
 if [ "$rc" != "0" ]; then
@@ -327,13 +357,20 @@ done
 echo "--------------------------------------"
 echo "INSTALLING GUARDIUM INSIGHTS OPERATORS"
 echo "--------------------------------------"
-cloudctl case launch \
-  --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
-  --namespace ${NAMESPACE} \
-  --inventory install \
-  --action install-operator \
-  --tolerance 1 \
-  --args "--registry cp.icr.io --user ${CP_REPO_USER} --pass ${CP_REPO_PASS} --secret ibm-entitlement-key"
+# cloudctl case launch \
+#   --case ${LOCAL_CASE_DIR}/${CASE_ARCHIVE} \
+#   --namespace ${NAMESPACE} \
+#   --inventory install \
+#   --action install-operator \
+#   --tolerance 1 \
+#   --args "--registry cp.icr.io --user ${CP_REPO_USER} --pass ${CP_REPO_PASS} --secret ibm-entitlement-key"
+
+oc ibm-pak launch ${CASE_NAME} \
+   --version ${CASE_VERSION} \
+   --inventory install \
+   --action install-operator \
+   --namespace ${NAMESPACE} \
+   --args "--registry cp.icr.io --user ${CP_REPO_USER} --pass ${CP_REPO_PASS} --secret ibm-entitlement-key --inputDir ${LOCAL_CASE_DIR}"
 # Checking exit status
 rc=$?
 if [ "$rc" != "0" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,12 +19,12 @@ export CP_REPO_PASS=$9
 export GI_VERSION=${10}
 export GI_PRODUCTION_SIZE=${11}
 
-if [ "$GI_VERSION" == "3.2.3" ]; then
-  export CASE_VERSION="2.2.3"
-  export CASE_ARCHIVE="ibm-guardium-insights-2.2.3.tgz"
-elif [ "$GI_VERSION" == "3.2.4" ]; then
-  export CASE_VERSION="2.2.4"
-  export CASE_ARCHIVE="ibm-guardium-insights-2.2.4.tgz"
+if [ "$GI_VERSION" == "3.2.7" ]; then
+  export CASE_VERSION="2.2.7"
+  export CASE_ARCHIVE="ibm-guardium-insights-2.2.7.tgz"
+elif [ "$GI_VERSION" == "3.2.6" ]; then
+  export CASE_VERSION="2.2.6"
+  export CASE_ARCHIVE="ibm-guardium-insights-2.2.6.tgz"
 else
   echo "IBM Security Guardium Insights Version not supported. Exiting..."
   exit 1

--- a/scripts/templates/ocs/deploy-with-olm.yaml
+++ b/scripts/templates/ocs/deploy-with-olm.yaml
@@ -25,7 +25,7 @@ metadata:
   name: ocs-operator
   namespace: openshift-storage
 spec:
-  channel: stable-4.10
+  channel: stable-4.12
   installPlanApproval: Automatic
   name: ocs-operator
   source: redhat-operators

--- a/scripts/templates/ocs/ocs-storagecluster.yaml
+++ b/scripts/templates/ocs/ocs-storagecluster.yaml
@@ -36,4 +36,4 @@ spec:
       replica: 3
       portable: true
       preparePlacement: {}
-  version: 4.10.0
+  version: 4.12.0

--- a/templates/guardium-insights-existing-vpc.template.yaml
+++ b/templates/guardium-insights-existing-vpc.template.yaml
@@ -310,9 +310,9 @@ Parameters:
     Type: String
   GIVersion:
     AllowedValues:
-      - '3.2.6'
       - '3.2.7'
-    Default: '3.2.7'
+      - '3.2.8'
+    Default: '3.2.8'
     Description: Version of IBM Security Guardium Insights to be deployed.
     Type: String
   Namespace:
@@ -832,7 +832,7 @@ Resources:
             chmod +x /quickstart/bootstrap.sh
             ./quickstart/bootstrap.sh
           -
-            AMI_ID: !FindInMap [AWSAMIRegionMap, !Ref "AWS::Region", COREOS]
+            AMI_ID: !FindInMap [AWSAMIRegionMap, !Ref "AWS::Region", RHEL79HVM]
   CleanUpLambda:
     Type: AWS::Lambda::Function
     Properties:

--- a/templates/guardium-insights-existing-vpc.template.yaml
+++ b/templates/guardium-insights-existing-vpc.template.yaml
@@ -310,9 +310,9 @@ Parameters:
     Type: String
   GIVersion:
     AllowedValues:
+      - '3.2.6'
       - '3.2.7'
-      - '3.2.8'
-    Default: '3.2.8'
+    Default: '3.2.7'
     Description: Version of IBM Security Guardium Insights to be deployed.
     Type: String
   Namespace:
@@ -832,7 +832,7 @@ Resources:
             chmod +x /quickstart/bootstrap.sh
             ./quickstart/bootstrap.sh
           -
-            AMI_ID: !FindInMap [AWSAMIRegionMap, !Ref "AWS::Region", RHEL79HVM]
+            AMI_ID: !FindInMap [AWSAMIRegionMap, !Ref "AWS::Region", COREOS]
   CleanUpLambda:
     Type: AWS::Lambda::Function
     Properties:

--- a/templates/guardium-insights-existing-vpc.template.yaml
+++ b/templates/guardium-insights-existing-vpc.template.yaml
@@ -310,9 +310,9 @@ Parameters:
     Type: String
   GIVersion:
     AllowedValues:
-      - '3.2.3'
-      - '3.2.4'
-    Default: '3.2.4'
+      - '3.2.6'
+      - '3.2.7'
+    Default: '3.2.7'
     Description: Version of IBM Security Guardium Insights to be deployed.
     Type: String
   Namespace:

--- a/templates/guardium-insights-new-vpc.template.yaml
+++ b/templates/guardium-insights-new-vpc.template.yaml
@@ -301,9 +301,9 @@ Parameters:
     Type: String
   GIVersion:
     AllowedValues:
-      - '3.2.6'
       - '3.2.7'
-    Default: '3.2.7'
+      - '3.2.8'
+    Default: '3.2.8'
     Description: Version of IBM Security Guardium Insights to be deployed.
     Type: String
   Namespace:

--- a/templates/guardium-insights-new-vpc.template.yaml
+++ b/templates/guardium-insights-new-vpc.template.yaml
@@ -301,9 +301,9 @@ Parameters:
     Type: String
   GIVersion:
     AllowedValues:
+      - '3.2.6'
       - '3.2.7'
-      - '3.2.8'
-    Default: '3.2.8'
+    Default: '3.2.7'
     Description: Version of IBM Security Guardium Insights to be deployed.
     Type: String
   Namespace:

--- a/templates/guardium-insights-new-vpc.template.yaml
+++ b/templates/guardium-insights-new-vpc.template.yaml
@@ -301,9 +301,9 @@ Parameters:
     Type: String
   GIVersion:
     AllowedValues:
-      - '3.2.3'
-      - '3.2.4'
-    Default: '3.2.4'
+      - '3.2.6'
+      - '3.2.7'
+    Default: '3.2.7'
     Description: Version of IBM Security Guardium Insights to be deployed.
     Type: String
   Namespace:


### PR DESCRIPTION
This is the first step on our journey to CAR status as requested by AWS.

This update replaces the soon to be deprecated cloudctl plugin with the new oc ibm-pak utility.

Also updates to the latest released 3.2.x GI version as we continue as our journey to CAR single image.